### PR TITLE
DPC: config-entry-only schema, typing corrections, and translation whitespace fix

### DIFF
--- a/custom_components/dpc/__init__.py
+++ b/custom_components/dpc/__init__.py
@@ -17,10 +17,12 @@ from homeassistant.const import (
     CONF_RADIUS,
     CONF_SCAN_INTERVAL,
 )
-from homeassistant.core import Config, HomeAssistant
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import event
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.typing import ConfigType
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .api import DpcApiClient, DpcApiException
@@ -34,13 +36,15 @@ from .const import (
     STARTUP_MESSAGE,
 )
 
+CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
-async def async_setup(hass: HomeAssistant, config: Config):
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up this integration using YAML is not supported."""
     return True
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up this integration using UI."""
     if hass.data.get(DOMAIN) is None:
         hass.data.setdefault(DOMAIN, {})

--- a/custom_components/dpc/translations/en.json
+++ b/custom_components/dpc/translations/en.json
@@ -24,7 +24,7 @@
         "step": {
             "user": {
                 "title": "DPC Options",
-                "description": "Minimum level of warning.: 1 (green/no warning), 2 (yellow / ordinary), 3 (orange / moderate), 4 (red / high). By selecting the minimum alert level, the sensor will be active only if the level is greater or equal to the one chosen. ",
+                "description": "Minimum level of warning.: 1 (green/no warning), 2 (yellow / ordinary), 3 (orange / moderate), 4 (red / high). By selecting the minimum alert level, the sensor will be active only if the level is greater or equal to the one chosen.",
                 "data": {
                     "binary_sensor": "Binary sensor enabled",
                     "sensor": "Sensor enabled",


### PR DESCRIPTION
### Motivation
- Declare the integration as config-entry-only to silence Home Assistant config schema warnings and reflect that YAML setup is not supported. 
- Align setup function signatures with Home Assistant typing conventions and explicit boolean return contracts. 
- Fix a translation lint error caused by trailing whitespace in the English translation. 

### Description
- Add `from homeassistant.helpers import config_validation as cv` and `CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)` to `custom_components/dpc/__init__.py` to mark the integration as config-entry-only. 
- Replace the `async_setup` signature with `async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:` and import `ConfigType` from `homeassistant.helpers.typing`. 
- Annotate `async_setup_entry` with a boolean return type (`-> bool`) for clearer typing. 
- Remove trailing whitespace from the `options.step.user.description` string in `custom_components/dpc/translations/en.json` to satisfy translation validators. 

### Testing
- `hassfest` validation initially failed with an `IndentationError` during parsing (exit code 1) before the fixes were applied. 
- Ran `python -m py_compile custom_components/dpc/__init__.py` which completed successfully. 
- No additional automated test suite was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961241340b08328a5ad541ad0d62cd0)