### PR TITLE
DPC: marca config-entry-only, annotazioni tipi, correzioni traduzioni, icona e permessi

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Now the integration is added to HACS and available in the normal HA integration 
    3. Municipality
    4. Update interval (minutes, default 30)
    5. Minimum level of warning. (int, default 2)
+   6. Radius (km, default 50)
 
    N.B Some municipalities border on multiple alert areas. With the option (3) "municipality" the search is done by name of the municipality, and the area with the highest alert will be considered.
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ Now the integration is added to HACS and available in the normal HA integration 
    3. Municipality
    4. Update interval (minutes, default 30)
    5. Minimum level of warning. (int, default 2)
-   6. Radius (km, default 50)
 
    N.B Some municipalities border on multiple alert areas. With the option (3) "municipality" the search is done by name of the municipality, and the area with the highest alert will be considered.
 

--- a/custom_components/dpc/__init__.py
+++ b/custom_components/dpc/__init__.py
@@ -17,10 +17,12 @@ from homeassistant.const import (
     CONF_RADIUS,
     CONF_SCAN_INTERVAL,
 )
-from homeassistant.core import Config, HomeAssistant
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import event
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.typing import ConfigType
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .api import DpcApiClient, DpcApiException
@@ -34,13 +36,16 @@ from .const import (
     STARTUP_MESSAGE,
 )
 
+CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
-async def async_setup(hass: HomeAssistant, config: Config):
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up this integration using YAML is not supported."""
+    del config
     return True
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up this integration using UI."""
     if hass.data.get(DOMAIN) is None:
         hass.data.setdefault(DOMAIN, {})
@@ -109,7 +114,9 @@ class DpcDataUpdateCoordinator(DataUpdateCoordinator):
         await self.async_request_refresh()
 
 
-async def async_update_options(hass, config_entry):
+async def async_update_options(
+    hass: HomeAssistant, config_entry: ConfigEntry
+) -> None:
     """Update options."""
     await hass.config_entries.async_reload(config_entry.entry_id)
 
@@ -132,7 +139,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return unloaded
 
 
-async def async_migrate_entry(hass, entry):
+async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     LOGGER.info("Migrating DPC entry from Version %s", entry.version)
     if entry.version == 1:
         entry.options = dict(entry.options)

--- a/custom_components/dpc/api.py
+++ b/custom_components/dpc/api.py
@@ -102,7 +102,7 @@ PHENOMENA_ICON = {
     21: "mdi:snowflake-variant",
     30: "mdi:weather-fog",
     31: "mdi:weather-hazy",
-    40: "mdi:wave" "mdi:sail-boat",
+    40: "mdi:wave",
     41: "mdi:waves",
     42: "mdi:hydro-power",
     50: "mdi:arrow-up-thick",
@@ -129,8 +129,8 @@ PHENOMENA_TYPE = {
         13: "frequenti raffiche",
     },
     "GELATE": {
-        20: "diffusa formazione di ghiaggio al suolo a quote collinari",
-        21: "diffusa formazione di ghiaggio al suolo a quote di pianura",
+        20: "diffusa formazione di ghiaccio al suolo a quote collinari",
+        21: "diffusa formazione di ghiaccio al suolo a quote di pianura",
     },
     "NEBBIE": {
         30: "diffuse nelle ore notturne e del primo mattino",

--- a/custom_components/dpc/string.json
+++ b/custom_components/dpc/string.json
@@ -24,7 +24,7 @@
         "step": {
             "user": {
                 "title": "DPC Options",
-                "description": "Minimum level of warning.: 1 (green/no warning), 2 (yellow / ordinary), 3 (orange / moderate), 4 (red / high). By selecting the minimum alert level, the sensor will be active only if the level is greater or equal to the one chosen. ",
+                "description": "Minimum level of warning.: 1 (green/no warning), 2 (yellow / ordinary), 3 (orange / moderate), 4 (red / high). By selecting the minimum alert level, the sensor will be active only if the level is greater or equal to the one chosen.",
                 "data": {
                     "binary_sensor": "Binary sensor enabled",
                     "sensor": "Sensor enabled",

--- a/custom_components/dpc/translations/en.json
+++ b/custom_components/dpc/translations/en.json
@@ -24,7 +24,7 @@
         "step": {
             "user": {
                 "title": "DPC Options",
-                "description": "Minimum level of warning.: 1 (green/no warning), 2 (yellow / ordinary), 3 (orange / moderate), 4 (red / high). By selecting the minimum alert level, the sensor will be active only if the level is greater or equal to the one chosen. ",
+                "description": "Minimum level of warning.: 1 (green/no warning), 2 (yellow / ordinary), 3 (orange / moderate), 4 (red / high). By selecting the minimum alert level, the sensor will be active only if the level is greater or equal to the one chosen.",
                 "data": {
                     "binary_sensor": "Binary sensor enabled",
                     "sensor": "Sensor enabled",


### PR DESCRIPTION
### Motivation
- Risolvere avvisi di schema e validazione (`hassfest`) marcando l’integrazione come config-entry-only e allineando le firme delle funzioni a Home Assistant.
- Rimuovere residui di conflitti/rebase e pulire import non usati per evitare errori di parsing.
- Correggere traduzioni che causavano errori di validazione e un paio di errori di contenuto nell’API (icona/termine errato).
- Normalizzare i permessi dei file modificati per evitare file eseguibili non intenzionali.

### Description
- Aggiunto `CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)` e importato `config_validation as cv` e `ConfigType` da `homeassistant.helpers.typing` in `custom_components/dpc/__init__.py`.
- Aggiornata la firma di `async_setup` in `async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:` e scartato il parametro non usato con `del config`, oltre ad aggiungere annotazioni di ritorno e tipi per `async_setup_entry`, `async_update_options` e `async_migrate_entry`.
- Sistemata la voce `PHENOMENA_ICON[40]` e corretto il termine italiano da "ghiaggio" a "ghiaccio" in `custom_components/dpc/api.py`.
- Rimosso lo spazio finale nella descrizione di `options.step.user.description` in `custom_components/dpc/translations/en.json` e `custom_components/dpc/string.json` e ripristinati i permessi file a `100644` per i file modificati.

### Testing
- Eseguito `git rebase origin/main`, risolti i conflitti locali in `custom_components/dpc/__init__.py` e push forzato con `git push --force-with-lease`, operazione andata a buon fine.
- Verificata l’assenza di marker di merge (`<<<<<<<`, `=======`, `>>>>>>>`) e controllo whitespace sulle traduzioni con ricerche nel repo, risultati OK.
- Eseguito `hassfest` in CI in fasi precedenti: sono state riscontrate errori (`IndentationError` / `SyntaxError`) dovuti a residui di conflitto prima delle correzioni, quindi il workflow CI è fallito in quei run.
- Dopo la risoluzione dei conflitti non sono stati riavviati tutti i validator/CI `hassfest` automaticamente in questa sessione, quindi non ci sono nuovi run CI completi qui.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961241340b08328a5ad541ad0d62cd0)