### PR TITLE
Bump integration version to 2026.1.1

### DIFF
--- a/custom_components/dpc/const.py
+++ b/custom_components/dpc/const.py
@@ -13,7 +13,7 @@ DOMAIN = "dpc"
 ISSUE_URL = "https://github.com/caiosweet/Home-Assistant-custom-components-DPC-Alert/issues"
 NAME = "Dipartimento Protezione Civile"
 MANUFACTURER = "Italian Government"
-VERSION = "2023.10.0"
+VERSION = "2026.1.1"
 
 # Config
 CONF_MUNICIPALITY = "municipality"

--- a/custom_components/dpc/manifest.json
+++ b/custom_components/dpc/manifest.json
@@ -7,5 +7,5 @@
 	"iot_class": "cloud_polling",
 	"issue_tracker": "https://github.com/caiosweet/Home-Assistant-custom-components-DPC-Alert/issues",
 	"requirements": [],
-	"version": "2023.10.0"
+	"version": "2026.1.1"
 }


### PR DESCRIPTION
### Motivation

- Update the integration version from `2023.10.0` to `2026.1.1` to reflect the new release.
- Ensure the package metadata and library constant are consistent for consumers and Home Assistant.

### Description

- Updated the `VERSION` constant in `custom_components/dpc/const.py` to `2026.1.1`.
- Updated the `version` field in `custom_components/dpc/manifest.json` to `2026.1.1`.
- Kept all other code and defaults unchanged to avoid behavioral modifications.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69615e7d3be883289f08ca716c7b7347)